### PR TITLE
Changed json width object from string to float

### DIFF
--- a/vuforia.py
+++ b/vuforia.py
@@ -184,7 +184,7 @@ def main():
     image = base64.b64encode(image_file.read())
     metadata_file = open('PATH_TO_METADATAFILE')
     metadata = base64.b64encode(metadata_file.read())
-    print v.add_target({"name": "zxczxc", "width": "320", "image": image, "application_metadata": metadata, "active_flag": 1})
+    print v.add_target({"name": "zxczxc", "width": 320.0, "image": image, "application_metadata": metadata, "active_flag": 1})
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Changed the json width object from a string ("320") to a float (320.0).  The string object was returning an an error when the script tried to add targets to a database, as Vuforia requests a float object.  A integer also seems to be acceptable.